### PR TITLE
Properly Initialize Repo + Code Health

### DIFF
--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -35,4 +35,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
       run: |
-        coveralls
+        coveralls --service=github

--- a/auto_trainer/test_trainer.py
+++ b/auto_trainer/test_trainer.py
@@ -24,7 +24,7 @@ class TestAutoTrainer(unittest.TestCase):
     param = {'test_key': 'test_value'}
     tags = ['bunch', 'of', 'tags']
 
-    mock_run = mock.Mock(config=param)
+    mock_run = mock.MagicMock(config=param)
     mock_wandb.return_value = mock_run
 
     trainer._WANDB = True
@@ -38,6 +38,51 @@ class TestAutoTrainer(unittest.TestCase):
     self.assertListEqual(kwargs['tags'], tags)
     self.assertDictEqual(config, param)
     self.assertEqual(run, mock_run)
+
+  def test_trainer_no_wandb(self):
+    trainer._WANDB = False
+    self.assertFalse(trainer._WANDB)
+
+    algo = 'test_ago'
+    policy = 'test_policy'
+    episodes = 69
+
+    parameters = mock.MagicMock(algorithm=algo, policy=policy, 
+                                episodes=episodes)
+    fake_env = mock.MagicMock()
+
+    mock_learn = mock.MagicMock()
+    mock_save = mock.MagicMock()
+    mock_model = mock.MagicMock()
+    mock_model.learn = mock_learn
+    mock_model.save = mock_save
+
+    mock_model_cls = mock.MagicMock()
+    mock_model_cls.return_value = mock_model
+
+    with mock.patch.dict(trainer.SUPPORTED_ALGORITHMS, 
+                         {algo: mock_model_cls}, clear=True):
+      model, config, run = trainer.train(fake_env, parameters, None)
+
+      self.assertEqual(model, mock_model)
+      self.assertEqual(config, parameters)
+      self.assertIsNone(run)
+
+      mock_model_cls.assert_called_once()
+      args, _ = mock_model_cls.call_args
+      self.assertTupleEqual(args, (policy, fake_env))
+
+      mock_learn.assert_called_once()
+      mock_learn_args, _ = mock_learn.call_args
+      self.assertTupleEqual(mock_learn_args, (episodes, ))
+
+      mock_save.assert_called_once()
+      mock_save_args, _ = mock_save.call_args
+
+      # If not using wandb, should save in 2-digit reps of 
+      # MonthDayHourMinSec, so the length of the run name should be 10 digits
+      # long
+      self.assertEqual(len(mock_save_args[0]), 10)
 
 
 if __name__ == '__main__':

--- a/auto_trainer/test_trainer.py
+++ b/auto_trainer/test_trainer.py
@@ -4,6 +4,7 @@ from auto_trainer import trainer
 from unittest import mock
 
 from wandb.integration.sagemaker import config
+from wandb.trigger import call
 
 
 class TestAutoTrainer(unittest.TestCase):
@@ -30,7 +31,11 @@ class TestAutoTrainer(unittest.TestCase):
     self.assertTrue(trainer._WANDB)
     
     config, run = trainer.get_synced_config(param, tags)
+    mock_wandb.assert_called_once()
 
+    _, kwargs = mock_wandb.call_args
+    self.assertDictEqual(kwargs['config'], param)
+    self.assertListEqual(kwargs['tags'], tags)
     self.assertDictEqual(config, param)
     self.assertEqual(run, mock_run)
 

--- a/auto_trainer/test_trainer.py
+++ b/auto_trainer/test_trainer.py
@@ -1,0 +1,21 @@
+import unittest
+
+from auto_trainer import trainer
+from unittest import mock
+
+
+class TestAutoTrainer(unittest.TestCase):
+  def test_synced_config_no_wandb(self):
+    param = {'test_key': 'test_value'}
+
+    trainer._WANDB = False
+    self.assertFalse(trainer._WANDB)
+
+    config, run = trainer.get_synced_config(param, ['bunch', 'of', 'tags'])
+    
+    self.assertDictEqual(config, param)
+    self.assertIsNone(run)
+
+
+if __name__ == '__main__':
+  pass

--- a/auto_trainer/test_trainer.py
+++ b/auto_trainer/test_trainer.py
@@ -3,6 +3,8 @@ import unittest
 from auto_trainer import trainer
 from unittest import mock
 
+from wandb.integration.sagemaker import config
+
 
 class TestAutoTrainer(unittest.TestCase):
   def test_synced_config_no_wandb(self):
@@ -15,6 +17,22 @@ class TestAutoTrainer(unittest.TestCase):
     
     self.assertDictEqual(config, param)
     self.assertIsNone(run)
+
+  @mock.patch('wandb.init')
+  def test_synced_config_wandb(self, mock_wandb):
+    param = {'test_key': 'test_value'}
+    tags = ['bunch', 'of', 'tags']
+
+    mock_run = mock.Mock(config=param)
+    mock_wandb.return_value = mock_run
+
+    trainer._WANDB = True
+    self.assertTrue(trainer._WANDB)
+    
+    config, run = trainer.get_synced_config(param, tags)
+
+    self.assertDictEqual(config, param)
+    self.assertEqual(run, mock_run)
 
 
 if __name__ == '__main__':

--- a/auto_trainer/test_trainer.py
+++ b/auto_trainer/test_trainer.py
@@ -3,9 +3,6 @@ import unittest
 from auto_trainer import trainer
 from unittest import mock
 
-from wandb.integration.sagemaker import config
-from wandb.trigger import call
-
 
 class TestAutoTrainer(unittest.TestCase):
   def test_synced_config_no_wandb(self):
@@ -80,8 +77,8 @@ class TestAutoTrainer(unittest.TestCase):
       mock_save_args, _ = mock_save.call_args
 
       # If not using wandb, should save in 2-digit reps of 
-      # MonthDayHourMinSec, so the length of the run name should be 10 digits
-      # long
+      # MonthDayHourMinSec; henceforth, the length of the run name should be 10 
+      # digits # long
       self.assertEqual(len(mock_save_args[0]), 10)
 
 

--- a/auto_trainer/trainer.py
+++ b/auto_trainer/trainer.py
@@ -44,6 +44,8 @@ def get_synced_config(parameters, tags: List[Text]):
   if not _WANDB:
     return parameters, None
 
+  print('here')
+  print(wandb)
   run = wandb.init(
     project=PROJECT_NAME,
     entity=ENTITY,

--- a/auto_trainer/trainer.py
+++ b/auto_trainer/trainer.py
@@ -1,3 +1,5 @@
+from typing import List, Text
+
 from datetime import datetime
 import stable_baselines
 import logging
@@ -21,7 +23,22 @@ except ImportError:
   _WANDB = False
 
 
-def get_synced_config(parameters, tags):
+def get_synced_config(parameters, tags: List[Text]):
+  """Sync the config with wandb (if necessary) and return the new config
+
+  Args:
+    parameters (Any W&B supported type): The current hyperparameters to use. If
+      W&B is enabled and is actively making making a sweep, these 
+      hyperparameters will get updated to W&B's sweep. This can be any type
+      supported by W&B, including Dicts and argparse.Namespace objects.
+    tags (List[Text]): Tags that describe the run. Note that this is basically
+      useless if W&B is disabled.
+
+  Returns:
+    The (hyperparameter config, W&B run object). Obviously, if W&B is disabled,
+    then the run object will be None and the hyperparameter config will be what
+    was passed in. 
+  """
   if not _WANDB:
     return parameters, None
 

--- a/auto_trainer/trainer.py
+++ b/auto_trainer/trainer.py
@@ -30,9 +30,9 @@ def get_synced_config(parameters, tags: List[Text]):
 
   Args:
     parameters (Any W&B supported type): The current hyperparameters to use. If
-      W&B is enabled and is actively making making a sweep, these 
-      hyperparameters will get updated to W&B's sweep. This can be any type
-      supported by W&B, including Dicts and argparse.Namespace objects.
+      W&B is enabled and is actively making a sweep, these hyperparameters will 
+      get updated to W&B's sweep. This can be any type supported by W&B, 
+      including Dicts and argparse.Namespace objects.
     tags (List[Text]): Tags that describe the run. Note that this is basically
       useless if W&B is disabled.
 

--- a/auto_trainer/trainer.py
+++ b/auto_trainer/trainer.py
@@ -44,8 +44,6 @@ def get_synced_config(parameters, tags: List[Text]):
   if not _WANDB:
     return parameters, None
 
-  print('here')
-  print(wandb)
   run = wandb.init(
     project=PROJECT_NAME,
     entity=ENTITY,

--- a/auto_trainer/trainer.py
+++ b/auto_trainer/trainer.py
@@ -67,7 +67,7 @@ def train(env, parameters, tags, full_logging=True, log_freq=100, run=None):
                     verbose=1)
 
   if _WANDB: wandb.tensorboard.monkeypatch._notify_tensorboard_logdir(
-      os.path.join(run.dir, '{}_1'.format(_DEFAULT_RUN_NAME)))
+    os.path.join(run.dir, '{}_1'.format(_DEFAULT_RUN_NAME)))
 
   model.learn(config.episodes, tb_log_name=_DEFAULT_RUN_NAME,
               log_interval=log_freq)

--- a/auto_trainer/trainer.py
+++ b/auto_trainer/trainer.py
@@ -1,9 +1,11 @@
 from typing import List, Text
 
 from datetime import datetime
-import stable_baselines
+
+import gym
 import logging
 import os
+import stable_baselines
 
 
 PROJECT_NAME = 'solo-rl-experiments'
@@ -54,7 +56,27 @@ def get_synced_config(parameters, tags: List[Text]):
   return config, run
   
 
-def train(env, parameters, tags, full_logging=True, log_freq=100, run=None):
+def train(env: gym.Env, parameters, tags: List[Text], 
+          full_logging: bool = False, log_freq: int = 100, run = None):
+  """Train a model.
+
+  Args:
+    env (gym.Env): Gym environment to train on.
+    parameters (Any W&B supported type): The hyperparameters to train with.
+      Refer to W&B for all of the support types.
+    tags (List[Text]): List of tags that describe this run. Doesn't do anything
+      if `run` is not None.
+    full_logging (bool, optional): Whether or not to log *everything*. Can fill
+      up space quick. Defaults to True.
+    log_freq (int, optional): How many steps to write the logs. Defaults to 100.
+    run ([wandb.Run], optional): A current W&B run. Use this if you want to
+      reuse a current run, i.e. train a model, do things to it, and continue
+      training it. If this is None, a new run will be created via
+      `get_synced_config`. Defaults to None.
+
+  Returns:
+    [type]: [description]
+  """
   if run:
     config = parameters
   else: 

--- a/experiments/notebooks/solo8v2vanilla-ppo2.ipynb
+++ b/experiments/notebooks/solo8v2vanilla-ppo2.ipynb
@@ -435,7 +435,7 @@
     "extension": ".py",
     "format_name": "percent",
     "format_version": "1.3",
-    "jupytext_version": "1.7.1"
+    "jupytext_version": "1.9.1"
    }
   },
   "kernelspec": {

--- a/experiments/train/autotrainer-sb-solo-demo.py
+++ b/experiments/train/autotrainer-sb-solo-demo.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.7.1
+#       jupytext_version: 1.9.1
 #   kernelspec:
 #     display_name: Python 3
 #     language: python

--- a/experiments/train/solo8v2vanilla-ppo2.py
+++ b/experiments/train/solo8v2vanilla-ppo2.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.7.1
+#       jupytext_version: 1.9.1
 #   kernelspec:
 #     display_name: Python 3
 #     language: python

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(name='auto_trainer',
         'stable-baselines', 
         'numpy<1.19.0,>=1.16.0',
         'jupytext',
+        'gym'
       ], 
       extras_require={
         'cpu': ['tensorflow>=1.15.0,<2'],


### PR DESCRIPTION
Just doing what I should have done a while ago. Since I hadn't disable push access to `master` until today.... I've kinda just been pushing to it (read: **power trip**). So for documentation's case, I'll list down everything's that been done so far:
- Set up CI / CD (run tests + coverage)
- Created a test to ensure that jupyter notebooks and scripts are links at push time
- Created `auto_trainer`
  - So far only works with `stable_baselines` --will probably need to change that in the near future
  - Dynamic W&B compatibility
  - Docstrings
  - Tests
  - Turned into a package for auto install

So far, this is using `stable-baselines` as the algorithm implementations. If I can't figure out why `stable-baselines`'s PPO2 implementation is causing a memory leak, my next step is going to be to create a `Model` interface so I can implement my own algorithms using Tensorflow 2 and/or [TF-Agents](https://www.tensorflow.org/agents).