### PR TITLE
Fix W&B Reporting

### DIFF
--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -1,7 +1,7 @@
 # Run tests and send coverage report
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Build
+name: build
 
 on: [push, pull_request]
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 
 *.pyc
 *.egg-info/
+
+experiments/notebooks/**/logs/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Solo 8 Learning Experiments
+![build](https://github.com/WPI-MMR/learning_experiments/workflows/build/badge.svg?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/WPI-MMR/learning_experiments/badge.svg?branch=master)](https://coveralls.io/github/WPI-MMR/learning_experiments?branch=master)
+
 Experiments to try and get the solo 8 up and standing.
 
 ## Docker Execution Directions

--- a/auto_trainer/test_trainer.py
+++ b/auto_trainer/test_trainer.py
@@ -54,9 +54,10 @@ class TestAutoTrainer(unittest.TestCase):
     algo = 'test_ago'
     policy = 'test_policy'
     episodes = 69
+    epi_length = 10
 
     parameters = mock.MagicMock(algorithm=algo, policy=policy, 
-                                episodes=episodes)
+                                episodes=episodes, episode_length=epi_length)
     fake_env = mock.MagicMock()
 
     mock_learn = mock.MagicMock()
@@ -81,8 +82,9 @@ class TestAutoTrainer(unittest.TestCase):
       self.assertTupleEqual(args, (policy, fake_env))
 
       mock_learn.assert_called_once()
-      mock_learn_args, _ = mock_learn.call_args
-      self.assertTupleEqual(mock_learn_args, (episodes, ))
+      _, mock_learn_kwargs = mock_learn.call_args
+      self.assertEqual(mock_learn_kwargs['total_timesteps'], 
+                       episodes * epi_length)
 
       mock_save.assert_called_once()
       mock_save_args, _ = mock_save.call_args

--- a/bin/Dockerfile.stable-baselines
+++ b/bin/Dockerfile.stable-baselines
@@ -10,7 +10,7 @@ RUN mkdir /sources && cd /sources \
     && git clone https://github.com/WPI-MMR/learning_experiments.git \
     && python3.7 -m pip install -U pip wheel setuptools \
     && python3.7 -m pip install -e gym_solo/ \
-    && python3.7 -m pip install -e learning_experiments[gpu,wandb] \
+    && python3.7 -m pip install -e learning_experiments[gpu,wandb,mpi] \
     && python3.7 -m pip install jupyterlab
 
 WORKDIR /sources/learning_experiments/experiments

--- a/bin/Dockerfile.stable-baselines
+++ b/bin/Dockerfile.stable-baselines
@@ -1,7 +1,8 @@
 FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04
 
 RUN apt-get update \
-    && apt-get -y install git ffmpeg libsm6 libxext6 python3-pip python3.7-dev \
+    && apt-get -y install git ffmpeg libsm6 libxext6 cmake libopenmpi-dev \
+       zlib1g-dev python3-pip python3.7-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /sources && cd /sources \

--- a/experiments/notebooks/solo8v2vanilla-ppo2-vectorized.ipynb
+++ b/experiments/notebooks/solo8v2vanilla-ppo2-vectorized.ipynb
@@ -1,0 +1,504 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PPO2 on Solo8 v2 Vanilla w/ Fixed Timestamp & Vectorized Environments\n",
+    "Vectorized environment test"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Ensure that Tensorflow is using the GPU"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Default GPU Device: /device:GPU:0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import tensorflow as tf\n",
+    "if tf.test.gpu_device_name():\n",
+    "    print('Default GPU Device: {}'.format(tf.test.gpu_device_name()))\n",
+    "else:\n",
+    "    print(\"Please install GPU version of TF\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define Experiment Tags"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TAGS = ['solov2vanilla', 'gpu', 'home_pos_task']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get Solo Environment Configuration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import the relevant libraries + rewards & observations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.7/dist-packages/gym/logger.py:30: UserWarning: \u001b[33mWARN: Box bound precision lowered by casting to float32\u001b[0m\n",
+      "  warnings.warn(colorize('%s: %s'%('WARN', msg % args), 'yellow'))\n"
+     ]
+    }
+   ],
+   "source": [
+    "from gym_solo.envs import solo8v2vanilla\n",
+    "from gym_solo.core import obs\n",
+    "from gym_solo.core import rewards\n",
+    "from gym_solo.core import termination as terms\n",
+    "\n",
+    "import gym\n",
+    "import gym_solo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create the config for the enviornment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "env_config = solo8v2vanilla.Solo8VanillaConfig()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Parse CLI arguments and register w/ wandb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This experiment will be using the auto trainer to handle all of the hyperparmeter running"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:\n",
+      "The TensorFlow contrib module will not be included in TensorFlow 2.0.\n",
+      "For more information, please see:\n",
+      "  * https://github.com/tensorflow/community/blob/master/rfcs/20180907-contrib-sunset.md\n",
+      "  * https://github.com/tensorflow/addons\n",
+      "  * https://github.com/tensorflow/io (for I/O related ops)\n",
+      "If you depend on functionality not listed there, please file an issue.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from auto_trainer import params\n",
+    "import auto_trainer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create a basic config. Give the robot a total of 60 seconds simulation time to learn how to stand."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[34m\u001b[1mwandb\u001b[0m: Currently logged in as: \u001b[33magupta231\u001b[0m (use `wandb login --relogin` to force relogin)\n",
+      "/usr/local/lib/python3.7/dist-packages/IPython/html.py:14: ShimWarning: The `IPython.html` package has been deprecated since IPython 4.0. You should import from `notebook` instead. `IPython.html.widgets` has moved to `ipywidgets`.\n",
+      "  \"`IPython.html.widgets` has moved to `ipywidgets`.\", ShimWarning)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "                Tracking run with wandb version 0.10.17<br/>\n",
+       "                Syncing run <strong style=\"color:#cdcd00\">crisp-pyramid-91</strong> to <a href=\"https://wandb.ai\" target=\"_blank\">Weights & Biases</a> <a href=\"https://docs.wandb.com/integrations/jupyter.html\" target=\"_blank\">(Documentation)</a>.<br/>\n",
+       "                Project page: <a href=\"https://wandb.ai/wpi-mmr/solo-rl-experiments\" target=\"_blank\">https://wandb.ai/wpi-mmr/solo-rl-experiments</a><br/>\n",
+       "                Run page: <a href=\"https://wandb.ai/wpi-mmr/solo-rl-experiments/runs/2kv4wjfx\" target=\"_blank\">https://wandb.ai/wpi-mmr/solo-rl-experiments/runs/2kv4wjfx</a><br/>\n",
+       "                Run data is saved locally in <code>/sources/learning_experiments/experiments/notebooks/wandb/run-20210206_193250-2kv4wjfx</code><br/><br/>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'episodes': 10, 'episode_length': 1000, 'policy': 'MlpPolicy', 'algorithm': 'PPO2'}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "config = params.BaseParameters().parse()\n",
+    "\n",
+    "config.episodes = 10\n",
+    "# config.episode_length = 10 / env_config.dt\n",
+    "config.episode_length = 1000\n",
+    "\n",
+    "# auto_trainer.trainer._WANDB=False\n",
+    "config, run = auto_trainer.get_synced_config(config, TAGS)\n",
+    "config"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup Environment\n",
+    "Add the following inputs to the robot / environment:\n",
+    "\n",
+    "**Observations**\n",
+    "- TorsoIMU\n",
+    "- Motor encoder current values\n",
+    "\n",
+    "**Reward**\n",
+    "- How upright the TorsoIMU is. Valued in $[-1, 1]$\n",
+    "\n",
+    "**Termination Criteria**\n",
+    "- Terminate after $n$ timesteps"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_env(length):\n",
+    "    def _init():\n",
+    "        env = gym.make('solo8vanilla-v0', config=env_config)\n",
+    "\n",
+    "        env.obs_factory.register_observation(obs.TorsoIMU(env.robot))\n",
+    "        env.obs_factory.register_observation(obs.MotorEncoder(env.robot))\n",
+    "\n",
+    "        # env.reward_factory.register_reward(1, rewards.UprightReward(env.robot))\n",
+    "        env.reward_factory.register_reward(1, rewards.HomePositionReward(env.robot))\n",
+    "\n",
+    "        env.termination_factory.register_termination(terms.TimeBasedTermination(length))\n",
+    "        \n",
+    "        return env\n",
+    "    return _init"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Learning"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Hand-vectorize the environment. Note that this should be abstracted out into its own utility method eventually."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<stable_baselines.common.vec_env.subproc_vec_env.SubprocVecEnv at 0x7f1afd92fc90>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from stable_baselines.common.vec_env import SubprocVecEnv\n",
+    "\n",
+    "NUM_WORKERS = 4\n",
+    "env = SubprocVecEnv([make_env(config.episode_length) for _ in range(NUM_WORKERS)])\n",
+    "env"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Train on the vectorized environment instead"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/stable_baselines/common/tf_util.py:191: The name tf.ConfigProto is deprecated. Please use tf.compat.v1.ConfigProto instead.\n",
+      "\n",
+      "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/stable_baselines/common/tf_util.py:200: The name tf.Session is deprecated. Please use tf.compat.v1.Session instead.\n",
+      "\n",
+      "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/stable_baselines/common/policies.py:116: The name tf.variable_scope is deprecated. Please use tf.compat.v1.variable_scope instead.\n",
+      "\n",
+      "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/stable_baselines/common/input.py:25: The name tf.placeholder is deprecated. Please use tf.compat.v1.placeholder instead.\n",
+      "\n",
+      "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/stable_baselines/common/policies.py:561: flatten (from tensorflow.python.layers.core) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "Use keras.layers.flatten instead.\n",
+      "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/tensorflow_core/python/layers/core.py:332: Layer.apply (from tensorflow.python.keras.engine.base_layer) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "Please use `layer.__call__` method instead.\n",
+      "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/stable_baselines/common/tf_layers.py:123: The name tf.get_variable is deprecated. Please use tf.compat.v1.get_variable instead.\n",
+      "\n",
+      "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/stable_baselines/common/distributions.py:418: The name tf.random_normal is deprecated. Please use tf.random.normal instead.\n",
+      "\n",
+      "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/stable_baselines/ppo2/ppo2.py:190: The name tf.summary.scalar is deprecated. Please use tf.compat.v1.summary.scalar instead.\n",
+      "\n",
+      "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/stable_baselines/ppo2/ppo2.py:198: The name tf.trainable_variables is deprecated. Please use tf.compat.v1.trainable_variables instead.\n",
+      "\n",
+      "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/tensorflow_core/python/ops/math_grad.py:1424: where (from tensorflow.python.ops.array_ops) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "Use tf.where in 2.0, which has the same broadcast rule as np.where\n",
+      "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/stable_baselines/ppo2/ppo2.py:206: The name tf.train.AdamOptimizer is deprecated. Please use tf.compat.v1.train.AdamOptimizer instead.\n",
+      "\n",
+      "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/stable_baselines/ppo2/ppo2.py:240: The name tf.global_variables_initializer is deprecated. Please use tf.compat.v1.global_variables_initializer instead.\n",
+      "\n",
+      "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/stable_baselines/ppo2/ppo2.py:242: The name tf.summary.merge_all is deprecated. Please use tf.compat.v1.summary.merge_all instead.\n",
+      "\n",
+      "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/stable_baselines/common/base_class.py:1169: The name tf.summary.FileWriter is deprecated. Please use tf.compat.v1.summary.FileWriter instead.\n",
+      "\n",
+      "-------------------------------------\n",
+      "| approxkl           | 0.0020724821 |\n",
+      "| clipfrac           | 0.012207031  |\n",
+      "| explained_variance | 0.0126       |\n",
+      "| fps                | 569          |\n",
+      "| n_updates          | 1            |\n",
+      "| policy_entropy     | 17.029213    |\n",
+      "| policy_loss        | -0.008221899 |\n",
+      "| serial_timesteps   | 128          |\n",
+      "| time_elapsed       | 0.000262     |\n",
+      "| total_timesteps    | 512          |\n",
+      "| value_loss         | 16.60308     |\n",
+      "-------------------------------------\n",
+      "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/stable_baselines/common/tf_util.py:502: The name tf.Summary is deprecated. Please use tf.compat.v1.Summary instead.\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<br/>Waiting for W&B process to finish, PID 3862<br/>Program ended successfully."
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "Find user logs for this run at: <code>/sources/learning_experiments/experiments/notebooks/wandb/run-20210206_193250-2kv4wjfx/logs/debug.log</code>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "Find internal logs for this run at: <code>/sources/learning_experiments/experiments/notebooks/wandb/run-20210206_193250-2kv4wjfx/logs/debug-internal.log</code>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h3>Run summary:</h3><br/><style>\n",
+       "    table.wandb td:nth-child(1) { padding: 0 10px; text-align: right }\n",
+       "    </style><table class=\"wandb\">\n",
+       "<tr><td>global_step</td><td>10208</td></tr><tr><td>_timestamp</td><td>1612639982.79303</td></tr><tr><td>loss/entropy_loss</td><td>17.08247</td></tr><tr><td>loss/policy_gradient_loss</td><td>-0.00204</td></tr><tr><td>loss/value_function_loss</td><td>81.94783</td></tr><tr><td>loss/approximate_kullback-leibler</td><td>0.00066</td></tr><tr><td>loss/clip_factor</td><td>0.0</td></tr><tr><td>loss/loss</td><td>40.80105</td></tr><tr><td>input_info/discounted_rewards</td><td>19.10188</td></tr><tr><td>input_info/learning_rate</td><td>0.00025</td></tr><tr><td>input_info/advantage</td><td>0.0</td></tr><tr><td>input_info/clip_range</td><td>0.2</td></tr><tr><td>input_info/clip_range_vf</td><td>0.2</td></tr><tr><td>input_info/old_neglog_action_probability</td><td>17.21967</td></tr><tr><td>input_info/old_value_pred</td><td>6.50029</td></tr><tr><td>_step</td><td>303</td></tr><tr><td>episode_reward</td><td>805.40961</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h3>Run history:</h3><br/><style>\n",
+       "    table.wandb td:nth-child(1) { padding: 0 10px; text-align: right }\n",
+       "    </style><table class=\"wandb\">\n",
+       "<tr><td>global_step</td><td>▁▁▁▁▂▂▂▂▂▃▃▃▃▃▃▄▄▄▄▄▅▅▅▅▅▅▆▆▆▆▆▇▇▇▇▇▇███</td></tr><tr><td>_timestamp</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>loss/entropy_loss</td><td>▁▁▁▁▁▂▂▃▃▃▄▄▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▅▆▆▆▆▇▇████</td></tr><tr><td>loss/policy_gradient_loss</td><td>▇▃▂▇▁▆▅▆▆▆▆▆▆▇▆▆▇▆▄▆▅▇▇▆▆▆▆▄▆▆▇█▆▅▆▃▆▂▇▅</td></tr><tr><td>loss/value_function_loss</td><td>▁▁▁▄▃▆▆█▇██▇▇▆▆▃▃▁▁▃▃▆▆▇▇▆▇▆▅▆▄▄▁▁▁▁▄▄▆▆</td></tr><tr><td>loss/approximate_kullback-leibler</td><td>▁▃█▂▄▂▃▁▁▁▁▁▁▁▂▁▂▁▂▁▃▁▂▁▁▁▁▁▁▁▁▁▁▂▁▃▂▆▁▂</td></tr><tr><td>loss/clip_factor</td><td>▁▁█▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▆▁▁</td></tr><tr><td>loss/loss</td><td>▁▁▁▄▃▆▆█▇██▇▇▆▆▃▃▁▁▃▃▆▆▇▇▆▇▆▅▆▄▄▁▁▁▁▄▄▆▆</td></tr><tr><td>input_info/discounted_rewards</td><td>▁▁▁▄▃▅▅▆▆▆▆▆▆▅▅▄▄▃▃▅▅▇▆▇▇▆▆▆▅▆▅▅▃▃▅▅▇▇██</td></tr><tr><td>input_info/learning_rate</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>input_info/advantage</td><td>▇▃▆█▄▂▅▅▃▅▅▃▁▅▅▅▅▅▅▇▅▃▂▂▇▃▅▆▅▅▄▂▅▄▇▁▅█▁▅</td></tr><tr><td>input_info/clip_range</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>input_info/clip_range_vf</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>input_info/old_neglog_action_probability</td><td>▆▇▄▆▆▅▆▅▇▃▁▅█▆▄▆▄▅▃▄▄▇▆▅▃▆█▅▆▆▆▄▄▄▅█▃▇▇▆</td></tr><tr><td>input_info/old_value_pred</td><td>▁▁▁▁▁▂▂▂▂▂▂▂▂▂▂▃▃▅▅▅▅▄▄▄▄▄▄▃▃▃▄▄▆▆████▇▇</td></tr><tr><td>_step</td><td>▁▁▁▁▂▂▂▂▂▃▃▃▃▃▃▄▄▄▄▄▅▅▅▅▅▅▆▆▆▆▆▇▇▇▇▇▇███</td></tr><tr><td>episode_reward</td><td>█▁</td></tr></table><br/>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "Synced 5 W&B file(s), 0 media file(s), 0 artifact file(s) and 3 other file(s)"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "                    <br/>Synced <strong style=\"color:#cdcd00\">crisp-pyramid-91</strong>: <a href=\"https://wandb.ai/wpi-mmr/solo-rl-experiments/runs/2kv4wjfx\" target=\"_blank\">https://wandb.ai/wpi-mmr/solo-rl-experiments/runs/2kv4wjfx</a><br/>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "model, config, run = auto_trainer.train(env, config, TAGS, log_freq=100,\n",
+    "                                        full_logging=False, run=run)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<stable_baselines.ppo2.ppo2.PPO2 at 0x7f1b252a4ed0>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "text_representation": {
+    "extension": ".py",
+    "format_name": "percent",
+    "format_version": "1.3",
+    "jupytext_version": "1.9.1"
+   }
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/experiments/notebooks/solo8v2vanilla-ppo2.ipynb
+++ b/experiments/notebooks/solo8v2vanilla-ppo2.ipynb
@@ -70,7 +70,16 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.7/dist-packages/gym/logger.py:30: UserWarning: \u001b[33mWARN: Box bound precision lowered by casting to float32\u001b[0m\n",
+      "  warnings.warn(colorize('%s: %s'%('WARN', msg % args), 'yellow'))\n"
+     ]
+    }
+   ],
    "source": [
     "from gym_solo.envs import solo8v2vanilla\n",
     "from gym_solo.core import obs\n",
@@ -161,11 +170,11 @@
      "data": {
       "text/html": [
        "\n",
-       "                Tracking run with wandb version 0.10.14<br/>\n",
-       "                Syncing run <strong style=\"color:#cdcd00\">dauntless-dew-60</strong> to <a href=\"https://wandb.ai\" target=\"_blank\">Weights & Biases</a> <a href=\"https://docs.wandb.com/integrations/jupyter.html\" target=\"_blank\">(Documentation)</a>.<br/>\n",
+       "                Tracking run with wandb version 0.10.17<br/>\n",
+       "                Syncing run <strong style=\"color:#cdcd00\">ruby-smoke-92</strong> to <a href=\"https://wandb.ai\" target=\"_blank\">Weights & Biases</a> <a href=\"https://docs.wandb.com/integrations/jupyter.html\" target=\"_blank\">(Documentation)</a>.<br/>\n",
        "                Project page: <a href=\"https://wandb.ai/wpi-mmr/solo-rl-experiments\" target=\"_blank\">https://wandb.ai/wpi-mmr/solo-rl-experiments</a><br/>\n",
-       "                Run page: <a href=\"https://wandb.ai/wpi-mmr/solo-rl-experiments/runs/3dd8ljjl\" target=\"_blank\">https://wandb.ai/wpi-mmr/solo-rl-experiments/runs/3dd8ljjl</a><br/>\n",
-       "                Run data is saved locally in <code>/sources/learning_experiments/experiments/notebooks/wandb/run-20210120_164953-3dd8ljjl</code><br/><br/>\n",
+       "                Run page: <a href=\"https://wandb.ai/wpi-mmr/solo-rl-experiments/runs/1i9jghhv\" target=\"_blank\">https://wandb.ai/wpi-mmr/solo-rl-experiments/runs/1i9jghhv</a><br/>\n",
+       "                Run data is saved locally in <code>/sources/learning_experiments/experiments/notebooks/wandb/run-20210206_193512-1i9jghhv</code><br/><br/>\n",
        "            "
       ],
       "text/plain": [
@@ -178,7 +187,7 @@
     {
      "data": {
       "text/plain": [
-       "{'episodes': 500000, 'episode_length': 10000.0, 'policy': 'MlpPolicy', 'algorithm': 'PPO2'}"
+       "{'episodes': 750000, 'episode_length': 10000.0, 'policy': 'MlpPolicy', 'algorithm': 'PPO2'}"
       ]
      },
      "execution_count": 6,
@@ -189,7 +198,7 @@
    "source": [
     "config = params.BaseParameters().parse()\n",
     "\n",
-    "config.episodes = 500000\n",
+    "config.episodes = 750000\n",
     "config.episode_length = 10 / env_config.dt\n",
     "\n",
     "config, run = auto_trainer.get_synced_config(config, TAGS)\n",
@@ -249,7 +258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -287,216 +296,21 @@
       "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/stable_baselines/ppo2/ppo2.py:206: The name tf.train.AdamOptimizer is deprecated. Please use tf.compat.v1.train.AdamOptimizer instead.\n",
       "\n",
       "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/stable_baselines/ppo2/ppo2.py:240: The name tf.global_variables_initializer is deprecated. Please use tf.compat.v1.global_variables_initializer instead.\n",
-      "\n",
-      "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/stable_baselines/ppo2/ppo2.py:242: The name tf.summary.merge_all is deprecated. Please use tf.compat.v1.summary.merge_all instead.\n",
-      "\n",
-      "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/stable_baselines/common/base_class.py:1169: The name tf.summary.FileWriter is deprecated. Please use tf.compat.v1.summary.FileWriter instead.\n",
-      "\n",
-      "-------------------------------------\n",
-      "| approxkl           | 0.0037439335 |\n",
-      "| clipfrac           | 0.046875     |\n",
-      "| explained_variance | -0.146       |\n",
-      "| fps                | 209          |\n",
-      "| n_updates          | 1            |\n",
-      "| policy_entropy     | 17.031416    |\n",
-      "| policy_loss        | -0.023764359 |\n",
-      "| serial_timesteps   | 128          |\n",
-      "| time_elapsed       | 0.000361     |\n",
-      "| total_timesteps    | 128          |\n",
-      "| value_loss         | 16.367264    |\n",
-      "-------------------------------------\n",
-      "WARNING:tensorflow:From /usr/local/lib/python3.7/dist-packages/stable_baselines/common/tf_util.py:502: The name tf.Summary is deprecated. Please use tf.compat.v1.Summary instead.\n",
-      "\n",
-      "-------------------------------------\n",
-      "| approxkl           | 0.0033711412 |\n",
-      "| clipfrac           | 0.037109375  |\n",
-      "| explained_variance | 2.8e-05      |\n",
-      "| fps                | 658          |\n",
-      "| n_updates          | 500          |\n",
-      "| policy_entropy     | 17.77893     |\n",
-      "| policy_loss        | -0.014229813 |\n",
-      "| serial_timesteps   | 64000        |\n",
-      "| time_elapsed       | 108          |\n",
-      "| total_timesteps    | 64000        |\n",
-      "| value_loss         | 0.083649315  |\n",
-      "-------------------------------------\n",
-      "-------------------------------------\n",
-      "| approxkl           | 0.01039307   |\n",
-      "| clipfrac           | 0.1640625    |\n",
-      "| explained_variance | -4.17e-06    |\n",
-      "| fps                | 643          |\n",
-      "| n_updates          | 1000         |\n",
-      "| policy_entropy     | 18.356491    |\n",
-      "| policy_loss        | -0.019556215 |\n",
-      "| serial_timesteps   | 128000       |\n",
-      "| time_elapsed       | 205          |\n",
-      "| total_timesteps    | 128000       |\n",
-      "| value_loss         | 0.03686252   |\n",
-      "-------------------------------------\n",
-      "-------------------------------------\n",
-      "| approxkl           | 0.0046587335 |\n",
-      "| clipfrac           | 0.05859375   |\n",
-      "| explained_variance | 0.12         |\n",
-      "| fps                | 639          |\n",
-      "| n_updates          | 1500         |\n",
-      "| policy_entropy     | 19.051283    |\n",
-      "| policy_loss        | -0.016098373 |\n",
-      "| serial_timesteps   | 192000       |\n",
-      "| time_elapsed       | 303          |\n",
-      "| total_timesteps    | 192000       |\n",
-      "| value_loss         | 0.17098868   |\n",
-      "-------------------------------------\n",
-      "-------------------------------------\n",
-      "| approxkl           | 0.0024070772 |\n",
-      "| clipfrac           | 0.017578125  |\n",
-      "| explained_variance | -0.0238      |\n",
-      "| fps                | 700          |\n",
-      "| n_updates          | 2000         |\n",
-      "| policy_entropy     | 19.791578    |\n",
-      "| policy_loss        | -0.008710116 |\n",
-      "| serial_timesteps   | 256000       |\n",
-      "| time_elapsed       | 399          |\n",
-      "| total_timesteps    | 256000       |\n",
-      "| value_loss         | 3.191485     |\n",
-      "-------------------------------------\n",
-      "-------------------------------------\n",
-      "| approxkl           | 0.002767323  |\n",
-      "| clipfrac           | 0.015625     |\n",
-      "| explained_variance | -0.858       |\n",
-      "| fps                | 732          |\n",
-      "| n_updates          | 2500         |\n",
-      "| policy_entropy     | 20.192793    |\n",
-      "| policy_loss        | -0.010097688 |\n",
-      "| serial_timesteps   | 320000       |\n",
-      "| time_elapsed       | 495          |\n",
-      "| total_timesteps    | 320000       |\n",
-      "| value_loss         | 1.0288141    |\n",
-      "-------------------------------------\n",
-      "------------------------------------\n",
-      "| approxkl           | 0.006598054 |\n",
-      "| clipfrac           | 0.109375    |\n",
-      "| explained_variance | 0.874       |\n",
-      "| fps                | 727         |\n",
-      "| n_updates          | 3000        |\n",
-      "| policy_entropy     | 20.837326   |\n",
-      "| policy_loss        | -0.01856032 |\n",
-      "| serial_timesteps   | 384000      |\n",
-      "| time_elapsed       | 590         |\n",
-      "| total_timesteps    | 384000      |\n",
-      "| value_loss         | 0.19874567  |\n",
-      "------------------------------------\n",
-      "------------------------------------\n",
-      "| approxkl           | 0.002474167 |\n",
-      "| clipfrac           | 0.0234375   |\n",
-      "| explained_variance | 0.821       |\n",
-      "| fps                | 612         |\n",
-      "| n_updates          | 3500        |\n",
-      "| policy_entropy     | 21.560318   |\n",
-      "| policy_loss        | -0.01822483 |\n",
-      "| serial_timesteps   | 448000      |\n",
-      "| time_elapsed       | 684         |\n",
-      "| total_timesteps    | 448000      |\n",
-      "| value_loss         | 1.2775623   |\n",
-      "------------------------------------\n"
+      "\n"
      ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<br/>Waiting for W&B process to finish, PID 777<br/>Program ended successfully."
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Find user logs for this run at: <code>/sources/learning_experiments/experiments/notebooks/wandb/run-20210120_164953-3dd8ljjl/logs/debug.log</code>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Find internal logs for this run at: <code>/sources/learning_experiments/experiments/notebooks/wandb/run-20210120_164953-3dd8ljjl/logs/debug-internal.log</code>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<h3>Run summary:</h3><br/><style>\n",
-       "    table.wandb td:nth-child(1) { padding: 0 10px; text-align: right }\n",
-       "    </style><table class=\"wandb\">\n",
-       "<tr><td>global_step</td><td>500088</td></tr><tr><td>_timestamp</td><td>1611162155.99661</td></tr><tr><td>loss/entropy_loss</td><td>22.13864</td></tr><tr><td>loss/policy_gradient_loss</td><td>-0.01128</td></tr><tr><td>loss/value_function_loss</td><td>7.52694</td></tr><tr><td>loss/approximate_kullback-leibler</td><td>0.00873</td></tr><tr><td>loss/clip_factor</td><td>0.09375</td></tr><tr><td>loss/loss</td><td>3.5308</td></tr><tr><td>input_info/discounted_rewards</td><td>46.11958</td></tr><tr><td>input_info/learning_rate</td><td>0.00025</td></tr><tr><td>input_info/advantage</td><td>0.0</td></tr><tr><td>input_info/clip_range</td><td>0.2</td></tr><tr><td>input_info/clip_range_vf</td><td>0.2</td></tr><tr><td>input_info/old_neglog_action_probability</td><td>22.44969</td></tr><tr><td>input_info/old_value_pred</td><td>45.43156</td></tr><tr><td>_step</td><td>62498</td></tr><tr><td>episode_reward</td><td>6392.24072</td></tr></table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<h3>Run history:</h3><br/><style>\n",
-       "    table.wandb td:nth-child(1) { padding: 0 10px; text-align: right }\n",
-       "    </style><table class=\"wandb\">\n",
-       "<tr><td>global_step</td><td>▁▁▁▂▂▂▂▂▂▃▃▃▃▃▃▄▄▄▄▄▅▅▅▅▅▅▆▆▆▆▆▇▇▇▇▇▇███</td></tr><tr><td>_timestamp</td><td>▁▂▂▂▂▂▂▃▃▃▃▃▃▃▅▅▅▅▅▅▆▆▆▆▆▆▆▇▇▇▇▇▇▇██████</td></tr><tr><td>loss/entropy_loss</td><td>▁▁▁▂▂▂▂▂▂▃▃▃▃▃▄▄▄▄▄▅▅▅▅▅▅▅▅▆▆▆▆▆▇▇▇▇▇███</td></tr><tr><td>loss/policy_gradient_loss</td><td>▇▇▆▄▄▅▅▅▇▃▄▃▆▃▄▂▅▆▁▅█▆▆▆▃▃▅▆▂▇▃▆▄▃▅▆▂▃▅▆</td></tr><tr><td>loss/value_function_loss</td><td>▅▂▁▁▁▁▁▇▁▁▁█▁▁▁▁▁▁▁▁▇▂▁▁▁▂▁▁▂▁▂▁▁▁▂▂▁▂▁▁</td></tr><tr><td>loss/approximate_kullback-leibler</td><td>▁▁▃▃▅▅▅▃▂█▄▃▂▅▃▆▆▅▅▃▃▁▅▅▆▄▂▄▅▂▃▄▅▃▄▁▅▅▅▅</td></tr><tr><td>loss/clip_factor</td><td>▁▁▄▃▇▇▅▃▂▇▅▃▃▇▅█▇▆▇▅▅▁▇▇█▅▃▅▇▂▃▅▆▃▆▁▅▅▅▅</td></tr><tr><td>loss/loss</td><td>▅▂▁▁▁▁▁▇▁▁▁█▁▁▁▁▁▁▁▁▇▂▁▁▁▂▁▁▂▁▂▁▁▁▂▂▁▂▁▁</td></tr><tr><td>input_info/discounted_rewards</td><td>▄▅▇▇▅▅▅▅▆▅▅▁▆▄▅▆▇▇▄▆▂▇█▇▅▆▇▅▅▇█▆▆▅▇▆▅▆▆▅</td></tr><tr><td>input_info/learning_rate</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>input_info/advantage</td><td>█▃▃▃▃▃▃▃▃▃▃▄▃▃▇▃▃▃▃▃▇▂▃▃▃▄▃▁▃▃▂▃▃▃▄▅▃▃▁▃</td></tr><tr><td>input_info/clip_range</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>input_info/clip_range_vf</td><td>▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</td></tr><tr><td>input_info/old_neglog_action_probability</td><td>▁▁▂▂▂▂▃▃▃▃▃▃▄▃▄▅▄▃▅▆▅▆▆▅▆▅▆▅▆▆▇▇█▇▇▆████</td></tr><tr><td>input_info/old_value_pred</td><td>▃▆▇▇▆▅▅▆▆▅▆▁▇▅▅▇▇▇▄▆▂▇█▇▅▆▇▅▆▇█▆▆▆▇▇▆▆▆▅</td></tr><tr><td>_step</td><td>▁▁▁▂▂▂▂▂▂▃▃▃▃▃▃▄▄▄▄▄▅▅▅▅▅▅▆▆▆▆▆▇▇▇▇▇▇███</td></tr><tr><td>episode_reward</td><td>██▇▇▅▃▃▃▄▃▃▆▂▂▃▄▆▇▁▂▆▇█▇▇▃▄▄▃▆▆▆▄▅▄▆█▆▇█</td></tr></table><br/>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Synced 5 W&B file(s), 0 media file(s), 0 artifact file(s) and 3 other file(s)"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "                    <br/>Synced <strong style=\"color:#cdcd00\">dauntless-dew-60</strong>: <a href=\"https://wandb.ai/wpi-mmr/solo-rl-experiments/runs/3dd8ljjl\" target=\"_blank\">https://wandb.ai/wpi-mmr/solo-rl-experiments/runs/3dd8ljjl</a><br/>\n",
-       "                "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [
-    "model, config, run = auto_trainer.train(env, config, TAGS, log_freq=500, \n",
+    "model, config, run = auto_trainer.train(env, config, TAGS, log_freq=100,\n",
     "                                        full_logging=False, run=run)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,9 @@ from setuptools import setup, find_packages
 setup(name='auto_trainer', 
       version='0.0.1',
       python_requires='~=3.7',
+      packages=find_packages(),
       install_requires=[ 
-        'stable-baselines', 
+        'stable-baselines[mpi]', 
         'numpy<1.19.0,>=1.16.0',
         'jupytext',
         'gym'

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-from pkg_resources import DistributionNotFound, get_distribution
 from setuptools import setup, find_packages    
 
 
@@ -7,7 +6,7 @@ setup(name='auto_trainer',
       python_requires='~=3.7',
       packages=find_packages(),
       install_requires=[ 
-        'stable-baselines[mpi]', 
+        'stable-baselines', 
         'numpy<1.19.0,>=1.16.0',
         'jupytext',
         'gym'
@@ -16,5 +15,6 @@ setup(name='auto_trainer',
         'cpu': ['tensorflow>=1.15.0,<2'],
         'gpu': ['tensorflow-gpu==1.15.4'],
         'wandb': ['wandb'],
+        'mpi': ['stable-baselines[mpi]']
       }
 )


### PR DESCRIPTION
Fixed the issue where W&B wasn't able to track metrics when we were running multiple environments at once. Note that stable-baselines now requires `mpi`, which means that it won't work normally.

Thus, the only way to enable this breaking, multiprocessing behavior is to explicitly install `learning_experiments[mpi]`--so things shouldn't be breaking unless you expect them to :)